### PR TITLE
Fix flickering/wrong window being captured by slate capturer.

### DIFF
--- a/Source/MillicastPublisher/Private/Media/AudioGameCapturer.cpp
+++ b/Source/MillicastPublisher/Private/Media/AudioGameCapturer.cpp
@@ -114,11 +114,17 @@ IMillicastSource::FStreamTrackInterface AudioGameCapturer::StartCapture()
 
 void AudioGameCapturer::StopCapture()
 {
-	if(RtcAudioTrack) 
+	if(!RtcAudioTrack)
 	{
-		RtcAudioTrack = nullptr;
-		RtcAudioSource = nullptr;
+		return;
+	}
 
+	RtcAudioTrack = nullptr;
+	RtcAudioSource = nullptr;
+
+	// If engine exit requested then audio device is already destroyed.
+	if(!IsEngineExitRequested())
+	{
 		AudioDevice->UnregisterSubmixBufferListener(this, Submix);
 	}
 }

--- a/Source/MillicastPublisher/Private/Media/MillicastPublisherSource.cpp
+++ b/Source/MillicastPublisher/Private/Media/MillicastPublisherSource.cpp
@@ -171,11 +171,11 @@ void UMillicastPublisherSource::StartCapture(TFunction<void(IMillicastSource::FS
 		// If a render target has been set, create a Render Target capturer
 		if (RenderTarget != nullptr)
 		{
-			VideoSource = TUniquePtr<IMillicastVideoSource>(IMillicastVideoSource::Create(RenderTarget));
+			VideoSource = TSharedPtr<IMillicastVideoSource>(IMillicastVideoSource::Create(RenderTarget));
 		}
 		else
 		{
-			VideoSource = TUniquePtr<IMillicastVideoSource>(IMillicastVideoSource::Create());
+			VideoSource = IMillicastVideoSource::Create();
 		}
 
 		// Starts the capture and notify observers
@@ -187,7 +187,7 @@ void UMillicastPublisherSource::StartCapture(TFunction<void(IMillicastSource::FS
 	// If audio is enabled, create audio capturer
 	if (CaptureAudio)
 	{
-		AudioSource = TUniquePtr<IMillicastAudioSource>(IMillicastAudioSource::Create(AudioCaptureType));
+		AudioSource = TSharedPtr<IMillicastAudioSource>(IMillicastAudioSource::Create(AudioCaptureType));
 
 		if (AudioCaptureType == AudioCapturerType::DEVICE)
 		{

--- a/Source/MillicastPublisher/Private/Media/SlateWindowVideoCapturer.cpp
+++ b/Source/MillicastPublisher/Private/Media/SlateWindowVideoCapturer.cpp
@@ -66,7 +66,7 @@ void SlateWindowVideoCapturer::OnBackBufferReadyToPresent(SWindow& SlateWindow, 
 		check(IsInRenderingThread());
 
 		// Create and send webrtc video frame
-		RtcVideoSource->OnFrameReady(Buffer, true);
+		RtcVideoSource->OnFrameReady(Buffer);
 	}
 }
 

--- a/Source/MillicastPublisher/Private/Media/SlateWindowVideoCapturer.cpp
+++ b/Source/MillicastPublisher/Private/Media/SlateWindowVideoCapturer.cpp
@@ -1,16 +1,38 @@
 #include "SlateWindowVideoCapturer.h"
-
 #include "Framework/Application/SlateApplication.h"
-
 #include "WebRTC/PeerConnection.h"
 #include "MillicastPublisherPrivate.h"
-
 #include "Util.h"
 
-// Maybe return a TUniquePtr or Shared or somehting less ... raw
-IMillicastVideoSource* IMillicastVideoSource::Create()
+TSharedPtr<IMillicastVideoSource> IMillicastVideoSource::Create()
 {
-	return new SlateWindowVideoCapturer;
+	return SlateWindowVideoCapturer::CreateCapturer();
+}
+
+TSharedPtr<SlateWindowVideoCapturer> SlateWindowVideoCapturer::CreateCapturer()
+{
+	TSharedPtr<SlateWindowVideoCapturer> Capturer = TSharedPtr<SlateWindowVideoCapturer>(new SlateWindowVideoCapturer());
+	
+	// We create TWeakPtr here because we don't want gamethread keeping this alive if it is deleted before this async task happens.
+	TWeakPtr<SlateWindowVideoCapturer> WeakSelf = TWeakPtr<SlateWindowVideoCapturer>(Capturer);
+	AsyncTask(ENamedThreads::GameThread, [WeakSelf](){
+		TSharedPtr<SlateWindowVideoCapturer> Capturer = WeakSelf.Pin();
+		if(Capturer)
+		{
+			// We set the target window to the window with game viewport in it.
+			// Note: Calls to `FSlateApplication::Get()` have to on the GameThread, hence the AsyncTask.
+			FSlateApplication& SlateApp = FSlateApplication::Get();
+			TSharedPtr<SViewport> GameViewport = SlateApp.GetGameViewport();
+			Capturer->SetTargetWindow(SlateApp.FindWidgetWindow(GameViewport.ToSharedRef()));
+		}
+	});
+
+	return Capturer;
+}
+
+void SlateWindowVideoCapturer::SetTargetWindow(TSharedPtr<SWindow> InTargetWindow)
+{
+	TargetWindow = InTargetWindow;
 }
 
 IMillicastSource::FStreamTrackInterface SlateWindowVideoCapturer::StartCapture()
@@ -19,7 +41,7 @@ IMillicastSource::FStreamTrackInterface SlateWindowVideoCapturer::StartCapture()
 	RtcVideoSource = new rtc::RefCountedObject<FTexture2DVideoSourceAdapter>();
 
 	// Attach the callback to the Slate window renderer
-	FSlateApplication::Get().GetRenderer()->OnBackBufferReadyToPresent().AddRaw(this, 
+	OnBackBufferHandle = FSlateApplication::Get().GetRenderer()->OnBackBufferReadyToPresent().AddSP(this, 
 		&SlateWindowVideoCapturer::OnBackBufferReadyToPresent);
 
 	// Get the peerconnection factory to create the video track
@@ -44,8 +66,12 @@ void SlateWindowVideoCapturer::StopCapture()
 {
 	FScopeLock lock(&CriticalSection);
 
-	// Remove the callback to stop receiving new buffers
-	FSlateApplication::Get().GetRenderer()->OnBackBufferReadyToPresent().RemoveAll(this);
+	// We don't bother remove this callback on engine exit because renderer is already destroyed 
+	if (!IsEngineExitRequested())
+	{
+		// Remove the callback to stop receiving new buffers
+		FSlateApplication::Get().GetRenderer()->OnBackBufferReadyToPresent().Remove(OnBackBufferHandle);
+	}
 
 	// Destroy track and source
 	RtcVideoSource = nullptr;
@@ -59,14 +85,29 @@ SlateWindowVideoCapturer::FStreamTrackInterface SlateWindowVideoCapturer::GetTra
 
 void SlateWindowVideoCapturer::OnBackBufferReadyToPresent(SWindow& SlateWindow, const FTexture2DRHIRef& Buffer)
 {
+	checkf(IsInRenderingThread(), TEXT("Window capture must happen on the render thread."));
+
 	FScopeLock lock(&CriticalSection);
 
-	if (RtcVideoSource)
+	if(!RtcVideoSource)
 	{
-		check(IsInRenderingThread());
-
-		// Create and send webrtc video frame
-		RtcVideoSource->OnFrameReady(Buffer);
+		UE_LOG(LogMillicastPublisher, Warning, TEXT("FSlateWindowCapturer will skip capturing when video source has not been set."));
+		return;
 	}
+
+	if(!TargetWindow)
+	{
+		UE_LOG(LogMillicastPublisher, Warning, TEXT("FSlateWindowCapturer cannot capture a window when no target window has been set."));
+		return;
+	}
+
+	if(&SlateWindow != TargetWindow.Get())
+	{
+		// This is not our target window so skip it.
+		return;
+	}
+
+	// Create and send webrtc video frame
+	RtcVideoSource->OnFrameReady(Buffer);
 }
 

--- a/Source/MillicastPublisher/Private/Media/SlateWindowVideoCapturer.h
+++ b/Source/MillicastPublisher/Private/Media/SlateWindowVideoCapturer.h
@@ -4,24 +4,39 @@
 
 #include "IMillicastSource.h"
 #include "WebRTC/Texture2DVideoSourceAdapter.h"
+#include "Templates/SharedPointer.h"
 
 /**
 * This class is a video source capturer and captures video from the Slate Window renderer
 */
-class SlateWindowVideoCapturer : public IMillicastVideoSource
+class SlateWindowVideoCapturer : public IMillicastVideoSource, public TSharedFromThis<SlateWindowVideoCapturer>
 {
 	rtc::scoped_refptr<FTexture2DVideoSourceAdapter> RtcVideoSource;
 	FVideoTrackInterface RtcVideoTrack;
 	FCriticalSection CriticalSection;
+	TSharedPtr<SWindow> TargetWindow;
+	FDelegateHandle OnBackBufferHandle;
 
 public:
-	SlateWindowVideoCapturer() noexcept : RtcVideoSource(nullptr), RtcVideoTrack(nullptr) {}
+	static TSharedPtr<SlateWindowVideoCapturer> CreateCapturer();
 
+	/* Begin IMillicastVideoSource */
 	FStreamTrackInterface StartCapture() override;
 	void StopCapture() override;
 	FStreamTrackInterface GetTrack() override;
+	/* End IMillicastVideoSource */
+
+	/**
+	 * Window capturer can only capture one window at a time. 
+	 * Use this to specify which window to capture.
+	 * @param InTargetWindow The window to capture.
+	 **/
+	void SetTargetWindow(TSharedPtr<SWindow> InTargetWindow);
 
 private:
+	// Constructor explicitly private because we only want user to be create TSharedPtr of this type.
+	SlateWindowVideoCapturer() noexcept : RtcVideoSource(nullptr), RtcVideoTrack(nullptr) {}
+
 	/** Callback from the SlateWindowRenderer when a new frame buffer is ready */
 	void OnBackBufferReadyToPresent(SWindow& SlateWindow, const FTexture2DRHIRef& Buffer);
 };

--- a/Source/MillicastPublisher/Private/RHI/AsyncTextureReadback.cpp
+++ b/Source/MillicastPublisher/Private/RHI/AsyncTextureReadback.cpp
@@ -1,0 +1,134 @@
+// Copyright Millicast 2022. All Rights Reserved.
+
+#include "AsyncTextureReadback.h"
+#include "GlobalShader.h"
+#include "ScreenRendering.h"
+#include "Runtime/Renderer/Private/ScreenPass.h"
+
+FAsyncTextureReadback::~FAsyncTextureReadback()
+{
+	GDynamicRHI->RHIUnmapStagingSurface(ReadbackTexture);
+	ReadbackBuffer = nullptr;
+}
+
+/*
+* Copy from one texture to another. If PixelFormat and resolution is the same just do a simple GPU<->GPU copy.
+* If resolution or PixelFormat are mismatched then we have to render the source texture into the destination texture.
+*/
+void CopyTexture(FRHICommandList& RHICmdList, FTexture2DRHIRef SourceTexture, FTexture2DRHIRef DestTexture)
+{
+	if (SourceTexture->GetFormat() == DestTexture->GetFormat()
+		&& SourceTexture->GetSizeX() == DestTexture->GetSizeX()
+		&& SourceTexture->GetSizeY() == DestTexture->GetSizeY())
+	{
+
+		RHICmdList.Transition(FRHITransitionInfo(SourceTexture, ERHIAccess::Unknown, ERHIAccess::CopySrc));
+		RHICmdList.Transition(FRHITransitionInfo(DestTexture, ERHIAccess::Unknown, ERHIAccess::CopyDest));
+
+		// source and dest are the same. simple copy
+		RHICmdList.CopyTexture(SourceTexture, DestTexture, {});
+	}
+	else
+	{
+		IRendererModule* RendererModule = &FModuleManager::GetModuleChecked<IRendererModule>("Renderer");
+
+		RHICmdList.Transition(FRHITransitionInfo(SourceTexture, ERHIAccess::Unknown, ERHIAccess::SRVMask));
+		RHICmdList.Transition(FRHITransitionInfo(DestTexture, ERHIAccess::Unknown, ERHIAccess::RTV));
+
+		// source and destination are different. rendered copy
+		FRHIRenderPassInfo RPInfo(DestTexture, ERenderTargetActions::Load_Store);
+		RHICmdList.BeginRenderPass(RPInfo, TEXT("CopyTexture"));
+		{
+			FGlobalShaderMap* ShaderMap = GetGlobalShaderMap(GMaxRHIFeatureLevel);
+			TShaderMapRef<FScreenVS> VertexShader(ShaderMap);
+			TShaderMapRef<FScreenPS> PixelShader(ShaderMap);
+
+			RHICmdList.SetViewport(0, 0, 0.0f, DestTexture->GetSizeX(), DestTexture->GetSizeY(), 1.0f);
+
+			FGraphicsPipelineStateInitializer GraphicsPSOInit;
+			RHICmdList.ApplyCachedRenderTargets(GraphicsPSOInit);
+			GraphicsPSOInit.BlendState = TStaticBlendState<>::GetRHI();
+			GraphicsPSOInit.RasterizerState = TStaticRasterizerState<>::GetRHI();
+			GraphicsPSOInit.DepthStencilState = TStaticDepthStencilState<false, CF_Always>::GetRHI();
+			GraphicsPSOInit.BoundShaderState.VertexDeclarationRHI = GFilterVertexDeclaration.VertexDeclarationRHI;
+			GraphicsPSOInit.BoundShaderState.VertexShaderRHI = VertexShader.GetVertexShader();
+			GraphicsPSOInit.BoundShaderState.PixelShaderRHI = PixelShader.GetPixelShader();
+			GraphicsPSOInit.PrimitiveType = PT_TriangleList;
+			SetGraphicsPipelineState(RHICmdList, GraphicsPSOInit, 0);
+
+			PixelShader->SetParameters(RHICmdList, TStaticSamplerState<SF_Point>::GetRHI(), SourceTexture);
+
+			FIntPoint TargetBufferSize(DestTexture->GetSizeX(), DestTexture->GetSizeY());
+			RendererModule->DrawRectangle(RHICmdList, 0, 0, // Dest X, Y
+				DestTexture->GetSizeX(),					// Dest Width
+				DestTexture->GetSizeY(),					// Dest Height
+				0, 0,										// Source U, V
+				1, 1,										// Source USize, VSize
+				TargetBufferSize,							// Target buffer size
+				FIntPoint(1, 1),							// Source texture size
+				VertexShader, EDRF_Default);
+		}
+
+		RHICmdList.EndRenderPass();
+
+		RHICmdList.Transition(FRHITransitionInfo(SourceTexture, ERHIAccess::SRVMask, ERHIAccess::CopySrc));
+		RHICmdList.Transition(FRHITransitionInfo(DestTexture, ERHIAccess::RTV, ERHIAccess::CopyDest));
+	}
+}
+
+void FAsyncTextureReadback::ReadbackAsync_RenderThread(FTexture2DRHIRef SourceTexture, TFunction<void(uint8*,int,int,int)> OnReadbackComplete)
+{
+	checkf(IsInRenderingThread(), TEXT("Texture readback can only occur on the rendering thread."));
+	Initialize(SourceTexture);
+
+	FRHICommandListImmediate& RHICmdList = FRHICommandListExecutor::GetImmediateCommandList();
+
+	// Copy the passed texture into a staging texture (we do this to ensure PixelFormat and texture type is correct for readback)
+	RHICmdList.Transition(FRHITransitionInfo(SourceTexture, ERHIAccess::Unknown, ERHIAccess::CopySrc));
+	RHICmdList.Transition(FRHITransitionInfo(StagingTexture, ERHIAccess::CopySrc, ERHIAccess::CopyDest));
+	CopyTexture(RHICmdList, SourceTexture, StagingTexture);
+
+	// Copy the staging texture from GPU to CPU
+	RHICmdList.Transition(FRHITransitionInfo(StagingTexture, ERHIAccess::CopyDest, ERHIAccess::CopySrc));
+	RHICmdList.Transition(FRHITransitionInfo(ReadbackTexture, ERHIAccess::CPURead, ERHIAccess::CopyDest));
+	RHICmdList.CopyTexture(StagingTexture, ReadbackTexture, {});
+	RHICmdList.Transition(FRHITransitionInfo(ReadbackTexture, ERHIAccess::CopyDest, ERHIAccess::CPURead));
+
+	TSharedRef<FAsyncTextureReadback> ThisRef = AsShared();
+	RHICmdList.EnqueueLambda([ThisRef, OnReadbackComplete](FRHICommandListImmediate&) {
+		uint8* Pixels = static_cast<uint8*>(ThisRef->ReadbackBuffer);
+		OnReadbackComplete(Pixels, ThisRef->Width, ThisRef->Height, ThisRef->MappedStride);
+	});
+	
+}
+
+void FAsyncTextureReadback::Initialize(FTexture2DRHIRef Texture)
+{
+	int InWidth = Texture->GetSizeX();
+	int InHeight = Texture->GetSizeY();
+	if (InWidth == Width && InHeight == Height)
+	{
+		// No need to initialize, we already have textures at the correct resolutions.
+		return;
+	}
+
+	Width = InWidth;
+	Height = InHeight;
+
+	// Create a staging texture with a resolution matching the texture passed in.
+	{
+		FRHIResourceCreateInfo CreateInfo(TEXT("TextureReadbackStagingTexture"));
+		StagingTexture = GDynamicRHI->RHICreateTexture2D(Width, Height, EPixelFormat::PF_B8G8R8A8, 1, 1, ETextureCreateFlags::RenderTargetable, ERHIAccess::CopySrc, CreateInfo);
+	}
+
+	// Create a texture mapped to CPU memory so we can do an easy readback
+	{
+		FRHIResourceCreateInfo CreateInfo(TEXT("MappedCPUReadbackTexture"));
+		ReadbackTexture = GDynamicRHI->RHICreateTexture2D(Width, Height, EPixelFormat::PF_B8G8R8A8, 1, 1, ETextureCreateFlags::CPUReadback, ERHIAccess::CPURead, CreateInfo);
+
+		int32 BufferWidth = 0, BufferHeight = 0;
+		GDynamicRHI->RHIMapStagingSurface(ReadbackTexture, nullptr, ReadbackBuffer, BufferWidth, BufferHeight);
+		MappedStride = BufferWidth;
+	}
+	
+}

--- a/Source/MillicastPublisher/Private/RHI/AsyncTextureReadback.h
+++ b/Source/MillicastPublisher/Private/RHI/AsyncTextureReadback.h
@@ -1,0 +1,32 @@
+// Copyright Millicast 2022. All Rights Reserved.
+
+#pragma once
+
+#include "RHIResources.h"
+#include "GenericPlatform/GenericPlatformMisc.h"
+
+/*
+* A mechanism to read a UE texture from GPU to CPU
+* without blocking the render thread.
+* Note: This method can be improved in future version of UE when DX12 and Vulkan fence/triggers are in the RHI properly.
+*/
+class FAsyncTextureReadback : public TSharedFromThis<FAsyncTextureReadback>
+{
+public:
+	FAsyncTextureReadback() = default;
+	virtual ~FAsyncTextureReadback();
+
+	void ReadbackAsync_RenderThread(FTexture2DRHIRef TextureToReadback, TFunction<void(uint8* /*Pixels*/, int /*Width*/, int /*Height*/, int /*Stride*/)> OnReadbackComplete);
+
+private:
+	void Initialize(FTexture2DRHIRef Texture);
+
+private:
+	int Width = 0;
+	int Height = 0;
+	FTexture2DRHIRef StagingTexture;
+	FTexture2DRHIRef ReadbackTexture;
+	int32 MappedStride = 0;
+	void* ReadbackBuffer = nullptr;
+
+};

--- a/Source/MillicastPublisher/Private/WebRTC/Texture2DFrameBuffer.h
+++ b/Source/MillicastPublisher/Private/WebRTC/Texture2DFrameBuffer.h
@@ -22,153 +22,33 @@ namespace libyuv {
 	}
 }
 
-class FTexture2DFrameBuffer : public webrtc::VideoFrameBuffer
+class FB8G8R8A8ToI420FrameBuffer : public webrtc::VideoFrameBuffer
 {
-	int Width;
-	int Height;
-
-	rtc::scoped_refptr<webrtc::I420Buffer> Buffer;
-
-	FTexture2DRHIRef TextureFrame;
-	FCriticalSection CriticalSection;
-	void* TextureData;
-
-	TUniquePtr<FRHIGPUTextureReadback> Readback;
-
 public:
-
-	explicit FTexture2DFrameBuffer(FTexture2DRHIRef SourceTexture) noexcept : TextureData(nullptr)
-	{
-		/* Get video farme height and  width */
-		Width = SourceTexture->GetSizeX();
-		Height = SourceTexture->GetSizeY();
-		TextureFrame = SourceTexture;
-		
-		ENQUEUE_RENDER_COMMAND(ReadSurfaceCommand)(
-			[this](FRHICommandListImmediate& RHICmdList)
-			{
-				FScopeLock Lock(&CriticalSection);
-
-				if (GDynamicRHI && GDynamicRHI->GetName() == FString(TEXT("D3D12")))
-				{
-					ReadTextureDX12(RHICmdList);
-				}
-				else
-				{
-					ReadTexture(RHICmdList);
-				}
-			});
-
-		// FlushRenderingCommands();
-	}
-	
-	void ReadTextureDX12(FRHICommandListImmediate& RHICmdList)
-	{
-		if (!Readback.IsValid())
-		{
-			Readback = MakeUnique<FRHIGPUTextureReadback>(TEXT("CaptureReadback"));
-		}
-
-		Readback->EnqueueCopy(RHICmdList, TextureFrame, FResolveRect(0, 0, Width, Height));
-		RHICmdList.BlockUntilGPUIdle();
-		check(Readback->IsReady());
-
-		TextureData = Readback->Lock(Width * Height * 4);
-		Readback->Unlock();
-	}
-
-	void ReadTexture(FRHICommandListImmediate& RHICmdList)
-	{
-		uint32 stride;
-		TextureData = (uint8*)RHICmdList.LockTexture2D(TextureFrame, 0, EResourceLockMode::RLM_ReadOnly, stride, true);
-
-		RHICmdList.UnlockTexture2D(TextureFrame, 0, true);
-	}
-
-	/** Get video frame width */
-	int width() const override { return Width; }
-
-	/** Get video frame height */
-	int height() const override { return Height; }
-
-	/** Get buffer type */
-	Type type() const override { return Type::kNative; }
-
-	/** Get the I420 buffer */
-	rtc::scoped_refptr<webrtc::I420BufferInterface> ToI420() override
+	explicit FB8G8R8A8ToI420FrameBuffer(uint8* B8G8R8A8Pixels, int InWidth, int InHeight, int InStride) noexcept
+		: Width(InWidth)
+		, Height(InHeight)
 	{
 		/* Create an I420 buffer */
-		FScopeLock Lock(&CriticalSection);
-
 		Buffer = webrtc::I420Buffer::Create(Width, Height);
 
 		uint8* DataY = Buffer->MutableDataY();
 		uint8* DataU = Buffer->MutableDataU();
 		uint8* DataV = Buffer->MutableDataV();
 
-		const auto STRIDES = Width * 4;
+		const auto STRIDES = InStride * 4;
 
-		if (TextureData) {
-			libyuv::ARGBToI420((uint8_t*)TextureData, STRIDES,
-				DataY, Buffer->StrideY(), DataU, Buffer->StrideU(), DataV, Buffer->StrideV(),
-				Width, Height);
-		}
-
-		return Buffer;
-	}
-};
-
-class FColorTexture2DFrameBuffer : public webrtc::VideoFrameBuffer
-{
-	int Width;
-	int Height;
-
-	rtc::scoped_refptr<webrtc::I420Buffer> Buffer;
-
-public:
-
-	explicit FColorTexture2DFrameBuffer(FTexture2DRHIRef SourceTexture) noexcept
-	{
-		/* Get video farme height and  width */
-		Width = SourceTexture->GetSizeX();
-		Height = SourceTexture->GetSizeY();
-
-		/* Create an I420 buffer */
-		Buffer = webrtc::I420Buffer::Create(Width, Height);
-
-
-		/* Convert the texture2d frame to YUV pixel format */
-		FRHICommandListImmediate& RHICommandList = FRHICommandListExecutor::GetImmediateCommandList();
-
-		const auto ARGB_BUFFER_SIZE = Width * Height * 4;
-		FIntRect Rect(0, 0, Width, Height);
-		TArray<FColor> ColorData;
-		uint8* TextureData = new uint8[ARGB_BUFFER_SIZE];
-
-		FReadSurfaceDataFlags ReadSurfaceData{};
-		ReadSurfaceData.SetMip(0);
-
-		RHICommandList.ReadSurfaceData(SourceTexture, Rect, ColorData, ReadSurfaceData);
-
-		for (uint64 i = 0; i < Width * Height; ++i) {
-			const int64 ind = i * 4;
-			TextureData[ind] = ColorData[i].B;
-			TextureData[ind + 1] = ColorData[i].G;
-			TextureData[ind + 2] = ColorData[i].R;
-			TextureData[ind + 3] = ColorData[i].A;
-		}
-
-		uint8* DataY = Buffer->MutableDataY();
-		uint8* DataU = Buffer->MutableDataU();
-		uint8* DataV = Buffer->MutableDataV();
-
-		/* The buffer is in BGRA, but for some reason, this is ARGGToI420 that we need to use */
-		const auto STRIDES = Width * 4;
-		libyuv::ARGBToI420(TextureData, STRIDES,
-			DataY, Buffer->StrideY(), DataU, Buffer->StrideU(), DataV, Buffer->StrideV(),
-			Width, Height);
-
-		delete[] TextureData;
+		libyuv::ARGBToI420(
+			B8G8R8A8Pixels,
+			STRIDES,
+			Buffer->MutableDataY(),
+			Buffer->StrideY(),
+			Buffer->MutableDataU(),
+			Buffer->StrideU(),
+			Buffer->MutableDataV(),
+			Buffer->StrideV(),
+			Buffer->width(),
+			Buffer->height());
 	}
 
 	/** Get video frame width */
@@ -185,4 +65,9 @@ public:
 	{
 		return Buffer;
 	}
+
+private:
+	int Width;
+	int Height;
+	rtc::scoped_refptr<webrtc::I420Buffer> Buffer;
 };

--- a/Source/MillicastPublisher/Private/WebRTC/Texture2DVideoSourceAdapter.h
+++ b/Source/MillicastPublisher/Private/WebRTC/Texture2DVideoSourceAdapter.h
@@ -4,15 +4,16 @@
 
 #include "WebRTCInc.h"
 #include "RHI.h"
+#include "RHI/AsyncTextureReadback.h"
 
 /** Video Source adapter to create webrtc video frame from a Texture 2D and push it into webrtc pipelines */
 class FTexture2DVideoSourceAdapter : public rtc::AdaptedVideoTrackSource
 {
 public:
-	FTexture2DVideoSourceAdapter() noexcept = default;
+	FTexture2DVideoSourceAdapter() noexcept;
 	~FTexture2DVideoSourceAdapter() = default;
 
-	void OnFrameReady(const FTexture2DRHIRef& FrameBuffer, bool ReadColor = false);
+	void OnFrameReady(const FTexture2DRHIRef& FrameBuffer);
 
 	webrtc::MediaSourceInterface::SourceState state() const override;
 	absl::optional<bool> needs_denoising() const override { return false; }
@@ -23,4 +24,5 @@ private:
 	bool AdaptVideoFrame(int64 TimestampUs, FIntPoint Resolution);
 
 	FCriticalSection CriticalSection;
+	TSharedPtr<FAsyncTextureReadback> AsyncTextureReadback;
 };

--- a/Source/MillicastPublisher/Public/IMillicastSource.h
+++ b/Source/MillicastPublisher/Public/IMillicastSource.h
@@ -4,6 +4,7 @@
 
 #include "Misc/Optional.h"
 #include "api/media_stream_interface.h"
+#include "Templates/SharedPointer.h"
 
 /** Interface to start a capture a write data to WebRTC buffers in order to publish audio/video to Millicast */
 class IMillicastSource
@@ -46,7 +47,7 @@ public:
 	using FVideoTrackInterface = rtc::scoped_refptr<webrtc::VideoTrackInterface>;
 
 	/** Creates VideoSource with SlateWindow Capture */
-	static IMillicastVideoSource* Create();
+	static TSharedPtr<IMillicastVideoSource> Create();
 	/** Creates VideoSource and capture from a RenderTarget */
 	static IMillicastVideoSource* Create(UTextureRenderTarget2D* RenderTarget);
 };

--- a/Source/MillicastPublisher/Public/MillicastPublisherSource.h
+++ b/Source/MillicastPublisher/Public/MillicastPublisherSource.h
@@ -5,9 +5,7 @@
 #include "Materials/MaterialInstanceDynamic.h"
 #include "StreamMediaSource.h"
 #include "IMillicastSource.h"
-
 #include "AudioCaptureDeviceInterface.h"
-
 #include "MillicastPublisherSource.generated.h"
 
 USTRUCT(BlueprintType)
@@ -148,6 +146,6 @@ public:
 	void StopCapture();
 
 private:
-	TUniquePtr<IMillicastVideoSource> VideoSource;
-	TUniquePtr<IMillicastAudioSource> AudioSource;
+	TSharedPtr<IMillicastVideoSource> VideoSource;
+	TSharedPtr<IMillicastAudioSource> AudioSource;
 };


### PR DESCRIPTION
The backbuffer callback returns the backbuffer for all SWindows that UE is rendering - meaning output log, blueprints etc would flicker back and forth over the main game window. This was more prevalent when streaming the editor.

The fix I introduced is to set a target window for the slate capturer. By default it will set the target window to the main game/editor window.

Additionally while introducing this new feature I noticed the application was not shutting down cleanly due to accessing deleted resources during the destructor on slate capturer and game audio capturer - so I added a quick guard against that.