### PR TITLE
Add support for publisher source/component initialization from blueprint

### DIFF
--- a/Source/MillicastPublisher/Private/Media/MillicastPublisherSource.cpp
+++ b/Source/MillicastPublisher/Private/Media/MillicastPublisherSource.cpp
@@ -32,6 +32,14 @@ void UMillicastPublisherSource::BeginDestroy()
 	Super::BeginDestroy();
 }
 
+void UMillicastPublisherSource::Initialize(const FString& InPublishingToken, const FString& InStreamName, const FString& InSourceId,const FString& InStreamUrl)
+{
+	PublishingToken = InPublishingToken;
+	SourceId = InSourceId;
+	StreamName = InStreamName;
+	StreamUrl = InStreamUrl;
+}
+
 /*
  * IMediaOptions interface
  */

--- a/Source/MillicastPublisher/Public/MillicastPublisherComponent.h
+++ b/Source/MillicastPublisher/Public/MillicastPublisherComponent.h
@@ -77,6 +77,7 @@ public:
 		Returns false, if the MediaSource is already been set. This is usually the case when this component is
 		initialized in Blueprints.
 	*/
+	UFUNCTION(BlueprintCallable, Category = "MillicastPublisher", META = (DisplayName = "Initialize"))
 	bool Initialize(UMillicastPublisherSource* InMediaSource = nullptr);
 
 	/**

--- a/Source/MillicastPublisher/Public/MillicastPublisherSource.h
+++ b/Source/MillicastPublisher/Public/MillicastPublisherSource.h
@@ -39,6 +39,9 @@ class MILLICASTPUBLISHER_API UMillicastPublisherSource : public UStreamMediaSour
 public:
 	UMillicastPublisherSource();
 
+	UFUNCTION(BlueprintCallable, Category = "MillicastPublisher", META = (DisplayName = "Initialize"))
+	void Initialize(const FString& InPublishingToken, const FString& InStreamName, const FString& InSourceId, const FString& InStreamUrl = "https://director.millicast.com/api/director/publish");
+
 	/** The Millicast Stream name. */
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category=Stream, AssetRegistrySearchable)
 	FString StreamName;


### PR DESCRIPTION
Howdy Millicast devs,

For our company's use-case, we have to create publisher sources and components programmatically in blueprints. I made a couple quick fixes to add this functionality to the existing plugin, and thought that it could be useful for others as well.

Cheers,
Grant

---

Changelog:
* Add `UMillicastPublisherSource::Initialize()`
* Add `BlueprintCallable` specifier to `UMillicastPublisherComponent::Initialize()`

Blueprint nodes in action:
![image](https://user-images.githubusercontent.com/37308267/218930665-e232b693-fa94-4943-bcea-58188237fe1f.png)