### PR TITLE
Add setters for video and audio codecs

### DIFF
--- a/Source/MillicastPublisher/Private/Components/MillicastPublisherComponent.cpp
+++ b/Source/MillicastPublisher/Private/Components/MillicastPublisherComponent.cpp
@@ -709,6 +709,30 @@ void UMillicastPublisherComponent::SetStartingBitrate(int Bps)
 	UpdateBitrateSettings();
 }
 
+bool UMillicastPublisherComponent::SetVideoCodec(EMillicastVideoCodecs InVideoCodec)
+{
+	if (IsPublishing())
+	{
+		UE_LOG(LogMillicastPublisher, Error, TEXT("Cannot set video codec while publishing"));
+		return false;
+	}
+
+	SelectedVideoCodec = InVideoCodec;
+	return true;
+}
+
+bool UMillicastPublisherComponent::SetAudioCodec(EMillicastAudioCodecs InAudioCodec)
+{
+	if (IsPublishing())
+	{
+		UE_LOG(LogMillicastPublisher, Error, TEXT("Cannot set audio codec while publishing"));
+		return false;
+	}
+
+	SelectedAudioCodec = InAudioCodec;
+	return true;
+}
+
 void UMillicastPublisherComponent::EnableStats(bool Enable)
 {
 	RtcStatsEnabled = Enable;

--- a/Source/MillicastPublisher/Public/MillicastPublisherComponent.h
+++ b/Source/MillicastPublisher/Public/MillicastPublisherComponent.h
@@ -125,6 +125,20 @@ public:
 	void SetStartingBitrate(int Bps);
 
 	/**
+	 * Set the video codec, must be called before Publish
+	 * Return true if the video codec is set successfully, false if it is not set
+	 */
+	UFUNCTION(BlueprintCallable, Category = "MillicastPublisher", META = (DisplayName = "SetVideoCodec"))
+	bool SetVideoCodec(EMillicastVideoCodecs InVideoCodec);
+
+	/**
+	 * Set the audio codec
+	 * Return true if the video codec is set successfully, false if it is not set
+	 */
+	UFUNCTION(BlueprintCallable, Category = "MillicastPublisher", META = (DisplayName = "SetAudioCodec"))
+	bool SetAudioCodec(EMillicastAudioCodecs InAudioCodec);
+
+	/**
 	* Enable RTC stats gathering
 	* Enter the cmd: ``stat millicast_publisher`` in order to display them
 	*/


### PR DESCRIPTION
Hey all,

Requesting to add more blueprint functionality, this time for setting the video and audio codecs in `UMillicastPublisherComponent`.

Thanks,
Grant

---

Changes:
* Add `bool SetVideoCodec(EMillicastVideoCodec)` for setting video codec
* Add `bool SetAudioCodec(EMillicastAudioCodec)` for setting audio codec