### PR TITLE
Fix Broken 5.1.0 Build

### DIFF
--- a/Source/MillicastPublisher/MillicastPublisher.Build.cs
+++ b/Source/MillicastPublisher/MillicastPublisher.Build.cs
@@ -109,7 +109,12 @@ namespace UnrealBuildTool.Rules
 					"d3d11.lib",
 				});
 
-                PrivateIncludePaths.AddRange(new string[] {
+				PublicIncludePaths.AddRange(
+				new string[] {
+					Path.Combine(ModuleDirectory, "Private")
+				});
+
+				PrivateIncludePaths.AddRange(new string[] {
 					"MillicastPublisher/Private",
                     Path.Combine(Path.GetFullPath(Target.RelativeEnginePath), "Source/ThirdParty/WebRTC/4147/Include/third_party/libyuv/include"), // for libyuv headers
 				});


### PR DESCRIPTION
Hello,

Build is currently broken on Unreal 5.1.0 because `Public/MillicastPublisherComponent.h` includes `Private/WebRTC/PeerConnection.h`, but the Build.cs file for the module has no public include for anything in `/Private/`. This PR adds a public include for this directory.

Thanks,
Grant