### PR TITLE
Added missing includes & Forward declared types

### DIFF
--- a/Source/MillicastPublisher/Private/Media/AudioSubmixCapturer.h
+++ b/Source/MillicastPublisher/Private/Media/AudioSubmixCapturer.h
@@ -3,7 +3,18 @@
 #pragma once
 
 #include "AudioCapturerBase.h"
-#include "Sound/SoundSubmix.h"
+#include "CoreTypes.h"
+#include "ISubmixBufferListener.h"
+#include "Misc/Optional.h"
+
+class FAudioDevice;
+class USoundSubmix;
+class UWorld;
+
+namespace Audio
+{
+	using FDeviceId = uint32;
+}
 
 namespace Millicast::Publisher
 {


### PR DESCRIPTION
The main change here is the addition of `ISubmixBufferListener.h` in order to unblock [5.3.2 compilation](https://github.com/millicast/millicast-publisher-unreal-engine-plugin/issues/62). However, I took the liberty to improve the rest of the file as well to demonstrate proper [IWYU principles](https://dev.epicgames.com/documentation/en-us/unreal-engine/include-what-you-use-iwyu-for-unreal-engine-programming):

- Forward declare if possible
- Include if necessary
- Don't rely on other headers to indirectly include your dependencies

A lot of studios (and some individual developers like me) use non-unity builds, which are much more sensitive to incorrect dependency handling. Unity builds are very forgiving, because many files get gobbled together into a single compilation unit, and more likely than not the dependencies end up being included one way or another; that's not best practice though.

Most other Millicast headers could use a cleanup pass in this respect as well.